### PR TITLE
Don't declare Windows 10 compatibility

### DIFF
--- a/src/java.base/windows/native/launcher/java.manifest
+++ b/src/java.base/windows/native/launcher/java.manifest
@@ -54,8 +54,6 @@
         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
         <!-- Windows 8.1 -->
         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-        <!-- Windows 10 -->
-        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       </application>
     </compatibility>
 


### PR DESCRIPTION
This is just to easily update this PR while maintaining comparison history. This is not needed for merging to upstream and probably won't be accepted.

This PR is a workaround to Intel EOL Drivers for HD Graphics 2000/3000 (seen in Sandy Bridge) and older. When Windows 10 compatibility is declared, the Intel graphics driver DLL will crash. This is commonly seen in Minecraft with launchers that use Java versions 8u60 and above.